### PR TITLE
WIP - Remove parsoid

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,13 @@ FROM node:7-alpine
 
 ENV LOG_LEVEL info
 
+RUN apk add --no-cache git librsvg librsvg-dev build-base
+
 COPY . /src
 
 WORKDIR /src
 
-RUN apk add --no-cache git librsvg librsvg-dev build-base \
-    && npm install --only=production  \
+RUN npm install --only=production  \
     && npm cache clean --force \
     && rm -rf /tmp/npm* /root/.node* /root/.npm
 

--- a/MR.yaml
+++ b/MR.yaml
@@ -30,6 +30,9 @@ paths:
 
   /{api:sys}:
     x-modules:
+      - path: projects/proxy.yaml
+        options:
+          backend_host_template: '{{"/{domain}/sys/legacy"}}'
       - spec:
           paths:
             /mathoid:
@@ -57,10 +60,10 @@ paths:
 #                        value_type: json
 #                      - name: section-offsets
 #                        value_type: json
-            /key_value: &sys_key_value
+            /legacy/key_value: &sys_key_value
               x-modules:
                 - path: sys/key_value.js
-            /page_revisions:
+            /legacy/page_revisions:
               x-modules:
                 - path: sys/page_revisions.js
             /post_data:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # mediawiki-node-services
-Run several mediawiki nodejs services (RESTBase, Parsoid) in a single docker
+Run several mediawiki nodejs services (RESTBase) in a single docker
 container. Useful for small / low-memory installs.
 
 See [config.yaml](config.yaml) for the main config file

--- a/config.yaml
+++ b/config.yaml
@@ -2,10 +2,10 @@
 # single process:
 #
 # - RESTBase
-# - Parsoid
 
 services:
   - name: restbase
+    module: hyperswitch
     app_base_path: ./node_modules/restbase
     conf:
       port: 7231
@@ -18,18 +18,19 @@ services:
       spec:
         x-request-filters:
           - path: lib/security_response_header_filter.js
+          - path: lib/normalize_headers_filter.js
         x-sub-request-filters:
           - type: default
             name: http
             options:
-            allow:
-              - pattern: '{env(MEDIAWIKI_API_URL,http://localhost/w/api.php)}'
-                forward_headers: true
-              - pattern: http://localhost:8142
-                forward_headers: true
-              - pattern: http://localhost:10042
-                forward_headers: true
-              - pattern: /^https?:\/\//
+              allow:
+                - pattern: '{env(MEDIAWIKI_API_URL,http://localhost/w/api.php)}'
+                  forward_headers: true
+                - pattern: http://localhost:8142
+                  forward_headers: true
+                - pattern: http://localhost:10042
+                  forward_headers: true
+                - pattern: /^https?:\/\//
         paths:
           /{domain:localhost}:
             x-modules:
@@ -41,7 +42,7 @@ services:
                     baseUriTemplate: "{{'http://{domain}:7231/{domain}/v1'}}"
                   parsoid:
                     # XXX Check Parsoid URL!
-                    host: http://localhost:8142
+                    host: '{env(MEDIAWIKI_REST_URL,http://localhost/w/rest.php)}'
                   table:
                     backend: sqlite
                     dbname: /data/restbase_tables.sqlite3
@@ -49,6 +50,9 @@ services:
                     retry_delay: 250
                     retry_limit: 10
                     show_sql: false
+                    storage_groups:
+                      - name: local
+                        domains: /./
                   mathoid:
                     host: '{env(MATHOID_HOST_PORT,http://localhost:10042)}'
                   mobileapps:
@@ -56,21 +60,6 @@ services:
                   citoid:
                     host: '{env(CITOID_URI,http://localhost:1970)}'
                   purged_cache_control: s-maxage=864000, max-age=86400
-          /{domain:wikimedia.org}:
-            x-modules:
-              - path: projects/wikimedia.org.yaml
-                options: *default_options
-  - name: parsoid
-    entrypoint: apiServiceWorker
-    conf:
-      useSelser: true
-      serverPort: 8142
-      serverInterface: 0.0.0.0
-      debug: false
-      mwApis:
-        - domain: localhost
-          prefix: localhost
-          uri: '{env(MEDIAWIKI_API_URL,http://localhost/w/api.php)}'
   - name: mathoid
     # a relative path or the name of an npm package, if different from name
     module: ./mathoid/app.js

--- a/mathoid.yaml
+++ b/mathoid.yaml
@@ -5,7 +5,8 @@ tags:
 paths:
   /math/check/{type}:
     post:
-      tags: ['Math']
+      tags:
+        - Math
       summary: Check and normalize a TeX formula.
       description: |
         Checks the supplied TeX formula for correctness and returns the
@@ -17,35 +18,47 @@ paths:
         and perform a GET request against that URL.
 
         Stability: [stable](https://www.mediawiki.org/wiki/API_versioning#Stable).
-      produces:
-        - application/json
-        - application/problem+json
       parameters:
         - name: type
           in: path
           description: The input type of the given formula; can be tex or inline-tex
-          type: string
           required: true
-          enum:
-            - tex
-            - inline-tex
-            - chem
-        - name: q
-          in: formData
-          description: The formula to check
-          type: string
-          required: true
-      responses:
-        '200':
-          description: Information about the checked formula
-        '400':
-          description: Invalid type
           schema:
-            $ref: '#/definitions/problem'
+            type: string
+            enum:
+              - tex
+              - inline-tex
+              - chem
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              required:
+                - q
+              properties:
+                q:
+                  type: string
+                  description: The formula to check
+        required: true
+      responses:
+        200:
+          description: Information about the checked formula
+          content:
+            application/json:
+              schema:
+                type: object
+        400:
+          description: Invalid type
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/problem'
         default:
           description: Error
-          schema:
-            $ref: '#/definitions/problem'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/problem'
       x-monitor: true
       x-amples:
         - title: Mathoid - check test formula
@@ -60,7 +73,7 @@ paths:
             headers:
               content-type: /^application\/json/
               x-resource-location: /.+/
-              cache-control: 'no-cache'
+              cache-control: no-cache
             body:
               success: true
               checked: /.+/
@@ -74,34 +87,41 @@ paths:
 
   /math/formula/{hash}:
     get:
-      tags: ['Math']
+      tags:
+        - Math
       summary: Get a previously-stored formula
       description: |
         Returns the previously-stored formula via `/media/math/check/{type}` for
         the given hash.
 
         Stability: [stable](https://www.mediawiki.org/wiki/API_versioning#Stable).
-      produces:
-        - application/json
-        - application/problem+json
       parameters:
         - name: hash
           in: path
           description: The hash string of the previous POST data
-          type: string
           required: true
-          minLength: 1
-      responses:
-        '200':
-          description: Information about the checked formula
-        '404':
-          description: Data for the given hash cannot be found
           schema:
-            $ref: '#/definitions/problem'
+            minLength: 1
+            type: string
+      responses:
+        200:
+          description: Information about the checked formula
+          content:
+            application/json:
+              schema:
+                type: object
+        404:
+          description: Data for the given hash cannot be found
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/problem'
         default:
           description: Error
-          schema:
-            $ref: '#/definitions/problem'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/problem'
       x-monitor: false
       x-request-handler:
         - get_from_sys:
@@ -112,7 +132,8 @@ paths:
 
   /math/render/{format}/{hash}:
     get:
-      tags: ['Math']
+      tags:
+        - Math
       summary: Get rendered formula in the given format.
       description: |
         Given a request hash, renders a TeX formula into its mathematic
@@ -122,66 +143,62 @@ paths:
         obtained, this endpoint has to be used to obtain the actual render.
 
         Stability: [stable](https://www.mediawiki.org/wiki/API_versioning#Stable).
-      produces:
-        - image/svg+xml
-        - application/mathml+xml
-        - image/png
-        - application/problem+json
       parameters:
         - name: format
           in: path
           description: The output format; can be svg or mml
-          type: string
           required: true
-          enum:
-            - svg
-            - mml
-            - png
+          schema:
+            type: string
+            enum:
+              - svg
+              - mml
+              - png
         - name: hash
           in: path
           description: The hash string of the previous POST data
-          type: string
           required: true
-          minLength: 1
-      responses:
-        '200':
-          description: The rendered formula
-        '404':
-          description: Unknown format or hash ID
           schema:
-            $ref: '#/definitions/problem'
+            minLength: 1
+            type: string
+      responses:
+        200:
+          description: The rendered formula
+          content:
+            image/svg+xml:
+              schema:
+                type: string
+            application/mathml+xml:
+              schema:
+                type: string
+            image/png:
+              schema:
+                type: string
+                format: binary
+        404:
+          description: Unknown format or hash ID
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/problem'
         default:
           description: Error
-          schema:
-            $ref: '#/definitions/problem'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/problem'
       x-monitor: false
-      x-setup-handler:
-        - init_svg:
-            uri: /{domain}/sys/key_value/mathoid_ng.svg
-            body:
-              keyType: string
-              valueType: string
-        - init_mml:
-            uri: /{domain}/sys/key_value/mathoid_ng.mml
-            body:
-              keyType: string
-              valueType: string
-        - init_png:
-            uri: /{domain}/sys/key_value/mathoid_ng.png
-            body:
-              keyType: string
-              valueType: blob
       x-request-handler:
         - check_storage:
             request:
               method: get
-              uri: /{domain}/sys/key_value/mathoid_ng.{$.request.params.format}/{$.request.params.hash}
+              uri: /{domain}/sys/key_value/mathoid_ng.{format}/{hash}
               headers:
                 cache-control: '{{ cache-control }}'
             catch:
               status: 404
             return_if:
-              status: '2xx'
+              status: 2xx
             return:
               status: 200
               headers: "{{ merge({ 'cache-control': options.cache-control }, check_storage.headers) }}"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   },
   "keywords": [
     "mediawiki",
-    "parsoid",
     "restbase",
     "docker"
   ],
@@ -27,11 +26,10 @@
     "url": "https://github.com/wikimedia/mediawiki-node-services/issues"
   },
   "dependencies": {
-    "parsoid": "^0.10",
-    "restbase": "wikimedia/restbase#1d0c716a8f28fe0812756853da5e322e866d5a95",
+    "restbase": "wikimedia/restbase#v1.1.4",
     "mathoid": "^0.7.2",
     "service-runner": "^2.6",
-    "restbase-mod-table-sqlite": "^1.1",
+    "restbase-mod-table-sqlite": "^1.2",
     "librsvg": "^0.7"
   }
 }


### PR DESCRIPTION
For mediawiki 1.35 and up

- use latest parsoid/php embedded in wiki instead of standalone
  parsoid/js
- update restbase version